### PR TITLE
Added Localization to the addon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased] - ui branch updates (2025-09-13)
+
+### Added
+
+- New options in the addon's configuration panel:
+  - Announcement Channel: choose where announcements are sent (Say, Party, Raid, Guild, Instance, Yell, Whisper, Channel).
+  - Target: player name (for Whisper) or channel number (for Channel).
+  - Show popup on join: toggle the popup when joining a Mythic+ group.
+  - Message Color: color picker for the popup's colored text.
+  - Test Announcement: an execute option to send a test announcement and show the popup.
+
+### Commands
+
+- New slash commands:
+  - `/mpk` — Open the addon options.
+  - `/mpk testpopup` — Show a test popup and send a test announcement.
+  - `/mpk last` — Print and show the last announced group popup.
+  - `/mpk resend` — Re-send the last plain announcement to the configured channel.
+
+### Fixes
+
+- Strip `|` characters from outgoing messages to avoid invalid chat escape code errors.
+- Use `C_ChatInfo.SendChatMessage` for chat output and added graceful fallbacks when configured channel is unavailable.
+

--- a/LFGMPLUSGROUP.lua
+++ b/LFGMPLUSGROUP.lua
@@ -2,6 +2,8 @@ LFGMythicPlus = LibStub("AceAddon-3.0"):NewAddon("MythicPlusKeyAnnouncer", "AceC
 local AceConfig = LibStub("AceConfig-3.0")
 local AceConfigDialog = LibStub("AceConfigDialog-3.0")
 local AceConfigRegistry = LibStub("AceConfigRegistry-3.0")
+local AceLocale = LibStub("AceLocale-3.0")
+local L = AceLocale:GetLocale("MythicPlusKeyAnnouncer")
 
 local currentLFGResults = ''
 local currentPlainLFGResults = ''
@@ -18,23 +20,23 @@ local defaults = {
 
 -- Options table for AceConfig
 local options = {
-	name = "Mythic Plus Key Announcer",
+	name = L["Mythic Plus Key Announcer"],
 	handler = LFGMythicPlus,
 	type = 'group',
 	args = {
 		sendChannel = {
 			type = "select",
-			name = "Announcement Channel",
-			desc = "Which chat channel to send the group filled message to.",
+			name = L["Announcement Channel"],
+			desc = L["Configure how group announcements are sent and displayed."],
 			values = {
-				SAY = "Say",
-				PARTY = "Party",
-				RAID = "Raid",
-				GUILD = "Guild",
-				INSTANCE_CHAT = "Instance",
-				YELL = "Yell",
-				WHISPER = "Whisper (requires target)",
-				CHANNEL = "Channel (requires channel number)",
+				SAY = L["Say"],
+				PARTY = L["Party"],
+				RAID = L["Raid"],
+				GUILD = L["Guild"],
+				INSTANCE_CHAT = L["Instance"],
+				YELL = L["Yell"],
+				WHISPER = L["Whisper (requires target)"],
+				CHANNEL = L["Channel (requires channel number)"],
 			},
 			get = function(info)
 				return LFGMythicPlus.db.profile.sendChannel
@@ -47,13 +49,14 @@ local options = {
 		},
 		sendTarget = {
 			type = "input",
-			name = "Target",
-			desc = "Player name for WHISPER or channel number for CHANNEL (e.g. 'SomePlayer' or '1').",
+			name = L["Target"],
+			desc = L["Target"],
 			get = function(info)
 				return LFGMythicPlus.db.profile.sendTarget
 			end,
 			set = function(info, val)
 				LFGMythicPlus.db.profile.sendTarget = val
+				if AceConfigRegistry then AceConfigRegistry:NotifyChange("MythicPlusKeyAnnouncer") end
 			end,
 			hidden = function()
 				local db = LFGMythicPlus.db and LFGMythicPlus.db.profile
@@ -65,25 +68,26 @@ local options = {
 		-- Test button to send a test announcement using current settings
 		testAnnouncement = {
 			type = "execute",
-			name = "Test Announcement",
-			desc = "Send a test announcement to the configured channel and show the popup.",
+			name = L["Test Announcement"],
+			desc = L["Test the configured announcement and popup."],
 			func = "TestAnnouncement",
 		},
 		showPopup = {
 			type = "toggle",
-			name = "Show popup on join",
-			desc = "Show a popup window when you join a Mythic+ group.",
+			name = L["Show popup on join"],
+			desc = L["Show a popup window when you join a Mythic+ group."],
 			get = function(info)
 				return LFGMythicPlus.db.profile.showPopup
 			end,
 			set = function(info, val)
 				LFGMythicPlus.db.profile.showPopup = val
+				if AceConfigRegistry then AceConfigRegistry:NotifyChange("MythicPlusKeyAnnouncer") end
 			end,
 		},
 		messageColor = {
 			type = "color",
-			name = "Message Color",
-			desc = "Set the color for the group filled chat message.",
+			name = L["Message Color"],
+			desc = L["Set the color for the group filled chat message."],
 			get = function(info)
 				local c = LFGMythicPlus.db.profile.messageColor
 				return c.r, c.g, c.b
@@ -91,6 +95,7 @@ local options = {
 			set = function(info, r, g, b)
 				local c = LFGMythicPlus.db.profile.messageColor
 				c.r, c.g, c.b = r, g, b
+				if AceConfigRegistry then AceConfigRegistry:NotifyChange("MythicPlusKeyAnnouncer") end
 			end,
 		},
 	},
@@ -102,7 +107,7 @@ local options = {
 function LFGMythicPlus:OnInitialize()
 	self.db = LibStub("AceDB-3.0"):New("MythicPlusKeyAnnouncerDB", defaults, true)
 	AceConfig:RegisterOptionsTable("MythicPlusKeyAnnouncer", options)
-	AceConfigDialog:AddToBlizOptions("MythicPlusKeyAnnouncer", "Mythic Plus Key Announcer")
+	AceConfigDialog:AddToBlizOptions("MythicPlusKeyAnnouncer", L["Mythic Plus Key Announcer"])
 	-- create Blizzard options panel when Blizzard UI is guaranteed to be ready
 	local loader = CreateFrame("Frame")
 	loader:RegisterEvent("PLAYER_LOGIN")
@@ -144,7 +149,7 @@ local function ShowGroupPopup(msg)
 	-- title
 	popupFrame.title = popupFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
 	popupFrame.title:SetPoint("TOPLEFT", popupFrame.icon, "TOPRIGHT", 8, -6)
-	popupFrame.title:SetText("Joined Mythic+ Group")
+	popupFrame.title:SetText(L["Joined Mythic+ Group"])
 	-- message
 	popupFrame.text = popupFrame:CreateFontString(nil, "OVERLAY", "GameFontNormal")
 	popupFrame.text:SetPoint("TOPLEFT", popupFrame.icon, "BOTTOMLEFT", 0, -6)
@@ -174,7 +179,7 @@ local function SendToConfiguredChannel(msg)
 			C_ChatInfo.SendChatMessage(msg, "WHISPER", nil, target)
 			return
 		else
-			print("MythicPlusKeyAnnouncer: no whisper target set, sending to SAY instead.")
+			print(("MythicPlusKeyAnnouncer: %s"):format(L["No whisper target set; sending to SAY."]))
 			C_ChatInfo.SendChatMessage(msg, "SAY")
 			return
 		end
@@ -187,7 +192,7 @@ local function SendToConfiguredChannel(msg)
 			C_ChatInfo.SendChatMessage(msg, "CHANNEL", nil, tostring(num))
 			return
 		else
-			print("MythicPlusKeyAnnouncer: invalid channel number, sending to SAY instead.")
+			print(("MythicPlusKeyAnnouncer: %s"):format(L["Invalid channel number; sending to SAY."]))
 			C_ChatInfo.SendChatMessage(msg, "SAY")
 			return
 		end
@@ -223,7 +228,7 @@ function LFGMythicPlus:ChatCommand(input)
 	if cmd == "testpopup" then
 		local msg = currentLFGResults
 		if not msg or msg == '' then
-			msg = "|cffFFD000 Mythic Plus Key Group:|r |cffDA70D6 TestDungeon:TestKey:15 |r"
+			msg = ("|cffFFD000 %s|r |cffDA70D6 TestDungeon:TestKey:15 |r"):format(L["Mythic Plus Key Group:"])
 		end
 		ShowGroupPopup(msg)
 		return
@@ -232,15 +237,15 @@ function LFGMythicPlus:ChatCommand(input)
 			print(currentLFGResults)
 			ShowGroupPopup(currentLFGResults)
 		else
-			print("MythicPlusKeyAnnouncer: No recent group found.")
+			print(("MythicPlusKeyAnnouncer: %s"):format(L["No recent group found."]))
 		end
 		return
 	elseif cmd == "resend" then
 		if currentPlainLFGResults and currentPlainLFGResults ~= '' then
 			SendToConfiguredChannel(currentPlainLFGResults)
-			print("MythicPlusKeyAnnouncer: Re-sent last announcement.")
+			print(("MythicPlusKeyAnnouncer: %s"):format(L["Re-sent last announcement."]))
 		else
-			print("MythicPlusKeyAnnouncer: No plain announcement available to resend.")
+			print(("MythicPlusKeyAnnouncer: %s"):format(L["No plain announcement available to resend."]))
 		end
 		return
 	else
@@ -260,12 +265,13 @@ function LFGMythicPlus:LFG_LIST_JOINED_GROUP(event, ...)
 		if searchResultInfo then
 			for _, activitiID in pairs(searchResultInfo.activityIDs) do
 				local activityInfoTable = C_LFGList.GetActivityInfoTable(activitiID)
-				msg = (GetColorHex() .. " Mythic Plus Key Group:|r |cffDA70D6  %s:%s:%s |r"):format(
+				msg = (GetColorHex() .. " %s|r |cffDA70D6  %s:%s:%s |r"):format(
+					L["Mythic Plus Key Group:"],
 					activityInfoTable.fullName,
 					tostring(searchResultInfo.name), tostring(searchResultInfo.comment))
 				currentLFGResults = msg
 				-- Send and store a plain-text version to the configured chat channel (strip color codes)
-				local plainMsg = ("Mythic Plus Key Group: %s:%s:%s"):format(
+				local plainMsg = ("%s %s:%s:%s"):format(L["Mythic Plus Key Group:"],
 					activityInfoTable.fullName,
 					tostring(searchResultInfo.name), tostring(searchResultInfo.comment))
 				currentPlainLFGResults = plainMsg
@@ -288,9 +294,10 @@ end
 -- Test announcement method invoked by the options panel button
 function LFGMythicPlus:TestAnnouncement()
 	local testDungeon, testKey, testLevel = "TestDungeon", "TestKey", "15"
-	local colored = (GetColorHex() .. " Mythic Plus Key Group:|r |cffDA70D6  %s:%s:%s |r"):format(testDungeon, testKey,
+	local colored = (GetColorHex() .. " %s|r |cffDA70D6  %s:%s:%s |r"):format(L["Mythic Plus Key Group:"], testDungeon,
+		testKey,
 		testLevel)
-	local plain = ("Mythic Plus Key Group: %s:%s:%s"):format(testDungeon, testKey, testLevel)
+	local plain = ("%s %s:%s:%s"):format(L["Mythic Plus Key Group:"], testDungeon, testKey, testLevel)
 	SendToConfiguredChannel(plain)
 	ShowGroupPopup(colored)
 end

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -1,0 +1,35 @@
+local AceLocale = LibStub("AceLocale-3.0")
+local L = AceLocale:NewLocale("MythicPlusKeyAnnouncer", "enUS", true)
+if not L then return end
+
+L["Mythic Plus Key Announcer"] = "Mythic Plus Key Announcer"
+L["Show popup on join"] = "Show popup on join"
+L["Message Color"] = "Message Color"
+L["Announcement Channel"] = "Announcement Channel"
+L["Whisper (requires target)"] = "Whisper (requires target)"
+L["Channel (requires channel number)"] = "Channel (requires channel number)"
+L["Target"] = "Target"
+L["Configure how group announcements are sent and displayed."] =
+"Configure how group announcements are sent and displayed."
+L["Say"] = "Say"
+L["Party"] = "Party"
+L["Raid"] = "Raid"
+L["Guild"] = "Guild"
+L["Instance"] = "Instance"
+L["Yell"] = "Yell"
+L["Test the configured announcement and popup."] = "Test the configured announcement and popup."
+L["Show a popup window when you join a Mythic+ group."] = "Show a popup window when you join a Mythic+ group."
+L["Set the color for the group filled chat message."] = "Set the color for the group filled chat message."
+L["Test Announcement"] = "Test Announcement"
+L["Configure how group announcements are sent and displayed."] =
+"Configure how group announcements are sent and displayed."
+L["Joined Mythic+ Group"] = "Joined Mythic+ Group"
+L["No whisper target set; sending to SAY."] = true
+L["Invalid channel number; sending to SAY."] = true
+L["Mythic Plus Key Group:"] = "Mythic Plus Key Group:"
+L["No recent group found."] = "No recent group found."
+L["Re-sent last announcement."] = "Re-sent last announcement."
+L["No plain announcement available to resend."] = "No plain announcement available to resend."
+L["Announcement channel set to %s"] = "Announcement channel set to %s"
+
+return L

--- a/Locales/esES.lua
+++ b/Locales/esES.lua
@@ -1,0 +1,35 @@
+local AceLocale = LibStub("AceLocale-3.0")
+local L = AceLocale:NewLocale("MythicPlusKeyAnnouncer", "esES")
+if not L then return end
+
+L["Mythic Plus Key Announcer"] = "Anunciador de Llaves Míticas"
+L["Show popup on join"] = "Mostrar ventana al unirse"
+L["Message Color"] = "Color del mensaje"
+L["Announcement Channel"] = "Canal de anuncio"
+L["Whisper (requires target)"] = "Susurro (requiere objetivo)"
+L["Channel (requires channel number)"] = "Canal (requiere número de canal)"
+L["Target"] = "Objetivo"
+L["Test Announcement"] = "Anuncio de prueba"
+L["Configure how group announcements are sent and displayed."] =
+"Configura cómo se envían y muestran los anuncios de grupo."
+L["Say"] = "Decir"
+L["Party"] = "Grupo"
+L["Raid"] = "Banda"
+L["Guild"] = "Hermandad"
+L["Instance"] = "Instancia"
+L["Yell"] = "Grito"
+L["Test the configured announcement and popup."] =
+"Envía un anuncio de prueba usando la configuración actual y muestra la ventana emergente."
+L["Show a popup window when you join a Mythic+ group."] =
+"Muestra una ventana emergente cuando te unes a un grupo Mítica+."
+L["Set the color for the group filled chat message."] = "Establece el color del mensaje de chat de grupo completado."
+L["Joined Mythic+ Group"] = "Unido a grupo Mítica+"
+L["No whisper target set; sending to SAY."] = "No se estableció un objetivo para susurrar; enviando a DECIR."
+L["Invalid channel number; sending to SAY."] = "Número de canal inválido; enviando a DECIR."
+L["Mythic Plus Key Group:"] = "Grupo de Llave Mítica:"
+L["No recent group found."] = "No se encontró un grupo reciente."
+L["Re-sent last announcement."] = "Reenviado el último anuncio."
+L["No plain announcement available to resend."] = "No hay anuncio simple disponible para reenviar."
+L["Announcement channel set to %s"] = "Canal de anuncio establecido a %s"
+
+return L

--- a/Locales/frFR.lua
+++ b/Locales/frFR.lua
@@ -1,0 +1,34 @@
+local AceLocale = LibStub("AceLocale-3.0")
+local L = AceLocale:NewLocale("MythicPlusKeyAnnouncer", "frFR")
+if not L then return end
+
+L["Mythic Plus Key Announcer"] = "Annonceur de clés Mythiques"
+L["Show popup on join"] = "Afficher la fenêtre à la jonction"
+L["Message Color"] = "Couleur du message"
+L["Announcement Channel"] = "Canal d'annonce"
+L["Whisper (requires target)"] = "Chuchoter (nécessite une cible)"
+L["Channel (requires channel number)"] = "Canal (nécessite un numéro de canal)"
+L["Target"] = "Cible"
+L["Test Announcement"] = "Annonce de test"
+L["Configure how group announcements are sent and displayed."] =
+"Configurer comment les annonces de groupe sont envoyées et affichées."
+L["Say"] = "Dire"
+L["Party"] = "Groupe"
+L["Raid"] = "Raid"
+L["Guild"] = "Guilde"
+L["Instance"] = "Instance"
+L["Yell"] = "Crier"
+L["Test the configured announcement and popup."] = "Testez l'annonce configurée et la fenêtre contextuelle."
+L["Show a popup window when you join a Mythic+ group."] =
+"Afficher une fenêtre contextuelle lorsque vous rejoignez un groupe Mythic+."
+L["Set the color for the group filled chat message."] = "Définir la couleur du message de chat de groupe rempli."
+L["Joined Mythic+ Group"] = "Groupe Mythic+ rejoint"
+L["No whisper target set; sending to SAY."] = "Aucune cible de chuchotement définie ; envoi en DIT."
+L["Invalid channel number; sending to SAY."] = "Numéro de canal invalide ; envoi en DIT."
+L["Mythic Plus Key Group:"] = "Groupe de Clef Mythique :"
+L["No recent group found."] = "Aucun groupe récent trouvé."
+L["Re-sent last announcement."] = "Dernière annonce renvoyée."
+L["No plain announcement available to resend."] = "Aucune annonce simple disponible pour renvoyer."
+L["Announcement channel set to %s"] = "Canal d'annonce défini sur %s"
+
+return L

--- a/Locales/zhCN.lua
+++ b/Locales/zhCN.lua
@@ -1,0 +1,32 @@
+local AceLocale = LibStub("AceLocale-3.0")
+local L = AceLocale:NewLocale("MythicPlusKeyAnnouncer", "zhCN")
+if not L then return end
+
+L["Mythic Plus Key Announcer"] = "史诗钥石组通知器"
+L["Show popup on join"] = "加入时显示弹窗"
+L["Message Color"] = "消息颜色"
+L["Announcement Channel"] = "公告频道"
+L["Whisper (requires target)"] = "密语（需要目标）"
+L["Channel (requires channel number)"] = "频道（需要频道编号）"
+L["Target"] = "目标"
+L["Test Announcement"] = "测试公告"
+L["Configure how group announcements are sent and displayed."] = "配置组公告的发送和显示方式。"
+L["Say"] = "说"
+L["Party"] = "队伍"
+L["Raid"] = "团队"
+L["Guild"] = "公会"
+L["Instance"] = "副本"
+L["Yell"] = "大喊"
+L["Test the configured announcement and popup."] = "使用当前设置发送测试公告并显示弹窗。"
+L["Show a popup window when you join a Mythic+ group."] = "当你加入神话+ 队伍时显示弹窗。"
+L["Set the color for the group filled chat message."] = "设置完成的队伍聊天消息颜色。"
+L["Joined Mythic+ Group"] = "已加入史诗+ 小队"
+L["No whisper target set; sending to SAY."] = "未设置密语目标；已改为在说话频道发送。"
+L["Invalid channel number; sending to SAY."] = "频道号码无效；已改为在说话频道发送。"
+L["Mythic Plus Key Group:"] = "史诗钥石队伍："
+L["No recent group found."] = "未找到最近的队伍。"
+L["Re-sent last announcement."] = "已重新发送最后一条公告。"
+L["No plain announcement available to resend."] = "没有可重新发送的简单公告。"
+L["Announcement channel set to %s"] = "公告频道已设置为 %s"
+
+return L

--- a/README.md
+++ b/README.md
@@ -1,3 +1,45 @@
 # Mythic-Plus-Key-Announcer
 
-World Of Warcraft Addon:  With this addon it will tell you in chat what LFG group you just joined and what key or raid it was for.
+Mythic-Plus-Key-Announcer is a small World of Warcraft addon that announces when you join a Mythic+ (or related) group and shows a popup with the group's key and details.
+
+## Features
+
+- Announce the Mythic+ key info to a configurable chat channel (Say, Party, Raid, Guild, Instance, Yell, Whisper, or a custom Channel).
+- Optional popup when you join a group, with configurable message color.
+- Test announcement button and slash commands to show/resend the last announcement.
+- Localization-ready (enUS, esES, frFR, zhCN included).
+
+## Installation
+
+Copy the addon folder into your World of Warcraft `_retail_/Interface/AddOns/` directory or use your preferred addon manager.
+
+## Usage
+
+- Open options with the slash command `/mpk` or via the AddOns options panel.
+- Configure the Announcement Channel and, if needed, the Target (player name for whispers or channel number for custom channels).
+- Toggle the popup and select the message color from the options.
+
+## Slash Commands
+
+- `/mpk` — Open the addon options.
+- `/mpk testpopup` — Show a test popup and send a test announcement.
+- `/mpk last` — Print and show the last announced group popup.
+- `/mpk resend` — Re-send the last plain announcement to the configured channel.
+
+## Documentation
+
+- Usage guide: `docs/USAGE.md`
+- Changelog: `CHANGELOG.md`
+
+## Notes
+
+- The addon strips `|` characters from outgoing messages to avoid invalid chat escape code errors.
+- Uses Ace3 libraries bundled in `Libs/`.
+
+## Contributing
+
+Contributions are welcome — open an issue or a pull request with changes. If you add translations, put them in the `Locales/` folder.
+
+## License
+
+See `Libs/LICENSE.txt` for Ace3 library licensing. The addon code itself is available under the same terms as the rest of the project (see repository LICENCE files).

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,49 @@
+# Mythic Plus Key Announcer — Usage
+
+This addon announces Mythic+ group keys and shows a popup when you join a group.
+
+## Options
+
+Open the options with `/mpk` or via AddOns → Mythic Plus Key Announcer in the Interface Options.
+
+- **Announcement Channel**
+
+	Choose where to send the announcement. Options include: Say, Party, Raid, Guild, Instance, Yell, Whisper (requires target), Channel (requires channel number).
+
+- **Target**
+
+	Enter a player name for Whisper or a channel number for Channel.
+
+- **Show popup on join**
+
+	Toggle whether a popup appears when you join a group.
+
+- **Message Color**
+
+	Pick the color used in the popup's colored text.
+
+- **Test Announcement**
+
+	Sends a test announcement using your current settings and shows the popup.
+
+## Slash commands
+
+- `/mpk` — Open the addon options.
+- `/mpk testpopup` — Show a test popup and send a test announcement.
+- `/mpk last` — Print and show the last announced group popup.
+- `/mpk resend` — Re-send the last plain announcement to the configured channel.
+
+## Notes
+
+- Whisper requires a valid player name in Target.
+- Channel requires a numeric channel ID in Target (for custom chat channels).
+- The addon strips any `|` characters from outgoing messages to avoid invalid chat escape codes.
+
+## Testing
+
+1. Reload the UI with `/reload`.
+2. Open options with `/mpk`.
+3. Configure channel and target if using Whisper/Channel.
+4. Click the Test Announcement button or run `/mpk testpopup`.
+
+If you find any missing strings in your locale, add them to the files in the `Locales/` folder.


### PR DESCRIPTION

### Added

- New options in the addon's configuration panel:
  - Announcement Channel: choose where announcements are sent (Say, Party, Raid, Guild, Instance, Yell, Whisper, Channel).
  - Target: player name (for Whisper) or channel number (for Channel).
  - Show popup on join: toggle the popup when joining a Mythic+ group.
  - Message Color: color picker for the popup's colored text.
  - Test Announcement: an execute option to send a test announcement and show the popup.
- Localization support for (English, Spanish, French, and Chinese)
### Commands

- New slash commands:
  - `/mpk` — Open the addon options.
  - `/mpk testpopup` — Show a test popup and send a test announcement.
  - `/mpk last` — Print and show the last announced group popup.
  - `/mpk resend` — Re-send the last plain announcement to the configured channel.

### Fixes

- Strip `|` characters from outgoing messages to avoid invalid chat escape code errors.
- Use `C_ChatInfo.SendChatMessage` for chat output and added graceful fallbacks when configured channel is unavailable.